### PR TITLE
Change Calendar.HOUR to Calendar.HOUR_OF_DAY

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ See https://github.com/inmite/android-validation-komensky/pull/35
         maven { url "https://jitpack.io" }
     }
 ```
- Step 2. Add the dependency in the form 
+ Step 2. Add the dependency in the form
 ```javascript
 	dependencies {
 	    compile 'com.github.douglasjunior:android-validation-komensky:0.9.4-1'
 	}
-``
+```

--- a/README.md
+++ b/README.md
@@ -1,128 +1,19 @@
 # ValidationKomensky for Android
 A simple library for validating user input in forms using annotations.
 
-![alt text](https://raw.github.com/inmite/android-validation-komensky/master/graphics/demo.png "user input validations")
+Forked from https://github.com/inmite/android-validation-komensky to fix a bug in FutureDateValidator.java
 
-Features:
+See https://github.com/inmite/android-validation-komensky/pull/35
 
- - Validate **all views at once** and show feedback to user. _With one line of code._
- - **Live validation** - check user input as he moves between views with immediate feedback.
- - **Extensible** library - you can add your own validations or adapters for custom views.
-
-## How to include it in your project:
-
-With Gradle:
-```groovy
-compile 'eu.inmite.android.lib:android-validation-komensky:0.9.4@aar'
+ Step 1. Add the JitPack repository to your build file
+```javascript
+    repositories {
+        maven { url "https://jitpack.io" }
+    }
 ```
-
-Manually:
-
- - clone the project
- - add it as library project in your IDE
-
-## How to validate
-
-First, annotate your views like this:
-```java
-@NotEmpty(messageId = R.string.validation_name)
-@MinLength(value = 3, messageId = R.string.validation_name_length, order = 2)
-private EditText mNameEditText;
-```
-
-Now you are ready to:
-```java
-FormValidator.validate(this, new SimpleErrorPopupCallback(this));
-```
-
-You will receive collection of all failed validations in a callback and you can present them to the user as you want.
-Or simply use prepared callbacks (like `SimpleErrorPopupCallback`).
-
-### Live validation
-
-To start and stop live validation, simply call:
-```java
-FormValidator.startLiveValidation(this, new SimpleErrorPopupCallback(this));
-FormValidator.stopLiveValidation(this);
-```
-
-### List of all supported validation annotations
-
-Validations supported out of the box:
- - [NotEmpty](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/NotEmpty.java)
-
-```java
-@NotEmpty(messageId = R.string.validation_name, order = 1)
-private EditText mNameEditText;
-```
- - [MaxLength](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/MaxLength.java)
- - [MinLength](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/MinLength.java)
-
-```java
-@MinLength(value = 1, messageId = R.string.validation_participants, order = 2)
-private EditText mNameEditText;
-```
- - [MaxValue](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/MaxValue.java)
- - [MinValue](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/MinValue.java)
-
-```java
-@MinValue(value = 2L, messageId = R.string.validation_name_length)
-private EditText mEditNumberOfParticipants;
-```
- - [MaxNumberValue](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/MaxNumber.java)
- - [MinNumberValue](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/MinNumberValue.java)
-
-```java
-@MinNumberValue(value = "5.5", messageId = R.string.validation_name_length)
-private EditText mEditPotentialOfHydrogen;
-```
- - [RegExp](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/RegExp.java)
-
-```java
-@RegExp(value = EMAIL, messageId = R.string.validation_valid_email)
-private EditText mEditEmail;
-@RegExp(value = "^[0-9]+$", messageId = R.string.validation_valid_count)
-private EditText mEditCount;
-```
- - [DateInFuture](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/DateInFuture.java)
-
-```java
-@DateInFuture(messageId = R.string.validation_date)
-private TextView mTxtDate;
-```
- - [DateNoWeekend](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/DateNoWeekend.java)
-
-```java
-@DateNoWeekend(messageId = R.string.validation_date_weekend)
-private TextView mTxtDate;
-```
- - [Custom](../master/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/Custom.java)
-
-```java
-@Custom(value = MyVeryOwnValidator.class, messageId = R.string.validation_custom)
-private EditText mNameEditText;
-```
-
-## Proguard
-
-Should you need to use the proguard, copy these rules:
-
-```proguard
--keepattributes *Annotation*
--keep class eu.inmite.android.lib.validations.form.annotations.** { *; }
--keep class * implements eu.inmite.android.lib.validations.form.iface.ICondition
--keep class * implements eu.inmite.android.lib.validations.form.iface.IValidator
--keep class * implements eu.inmite.android.lib.validations.form.iface.IFieldAdapter
--keepclassmembers class ** {
-	@eu.inmite.android.lib.validations.form.annotations.** *;
-}
-```
-
-## Why 'Komensky'?
-
-<img src="http://upload.wikimedia.org/wikipedia/commons/c/ce/Johan_amos_comenius_1592-1671.jpg" width="70"  align="right"/>
-
-[Jan Ámos Komenský](http://en.wikipedia.org/wiki/John_Amos_Comenius)  was a famous Czech educator, father of modern education methods.&nbsp;
-Teachers tend to correct you, just like this library. You won't miss any errors in the user input.
-
-See [**our other Czech personalities**](http://inmite.github.io) who help with [#AndroidDev](https://plus.google.com/s/%23AndroidDev).
+ Step 2. Add the dependency in the form 
+```javascript
+	dependencies {
+	    compile 'com.github.douglasjunior:android-validation-komensky:0.9.4-1'
+	}
+``

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ See https://github.com/inmite/android-validation-komensky/pull/35
  Step 2. Add the dependency in the form
 ```javascript
 	dependencies {
-	    compile 'com.github.douglasjunior:android-validation-komensky:0.9.4-1'
+	    compile 'com.github.douglasjunior:android-validation-komensky:bugfix-0.9.4'
 	}
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.3'
-        classpath 'org.robolectric:robolectric-gradle-plugin:1.1.0'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'org.robolectric'
 
 repositories {
     mavenCentral()
@@ -21,54 +20,5 @@ android {
 dependencies {
     compile 'com.android.support:support-v4:22.2.0'
     // Robolectric tests
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'com.squareup:fest-android:1.0.8@aar'
-    testCompile('org.robolectric:robolectric:2.4') {
-        exclude module: 'classworlds'
-        exclude module: 'commons-logging'
-        exclude module: 'httpclient'
-        exclude module: 'maven-artifact'
-        exclude module: 'maven-artifact-manager'
-        exclude module: 'maven-error-diagnostics'
-        exclude module: 'maven-model'
-        exclude module: 'maven-plugin-registry'
-        exclude module: 'maven-profile'
-        exclude module: 'maven-project'
-        exclude module: 'maven-settings'
-        exclude module: 'nekohtml'
-        exclude module: 'plexus-container-default'
-        exclude module: 'plexus-interpolation'
-        exclude module: 'plexus-utils'
-        exclude module: 'wagon-file'
-        exclude module: 'wagon-http-lightweight'
-        exclude module: 'wagon-http-shared'
-        exclude module: 'wagon-provider-api'
-    }
 }
 
-android.testOptions.unitTests.all {
-    // Configure includes / excludes
-    include '**/*Test.class'
-    exclude '**/espresso/**/*.class'
-
-    // Configure max heap size of the test JVM
-    maxHeapSize = '1024m'
-
-    // Configure the test JVM arguments - Does not apply to Java 8
-    jvmArgs '-XX:MaxPermSize=512m', '-XX:-UseSplitVerifier'
-
-    // Specify max number of processes (default is 1)
-    maxParallelForks = 4
-
-    // configure whether failing tests should fail the build
-    ignoreFailures true
-
-    // use afterTest to listen to the test execution results
-    afterTest { descriptor, result ->
-        println "Executing test for ${descriptor.name} with result: ${result.resultType}"
-    }
-}
-
-// Used to push in maven
-apply from: '../maven_push.gradle'

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/validators/FutureDateValidator.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/validators/FutureDateValidator.java
@@ -43,7 +43,7 @@ public class FutureDateValidator extends BaseDateValidator {
 	@Override
 	protected boolean validateDate(final Calendar cal, final Annotation annotation) {
 		final Calendar today = Calendar.getInstance();
-		today.set(HOUR, 0);
+		today.set(HOUR_OF_DAY, 0);
 		today.set(MINUTE, 0);
 		today.set(SECOND, 0);
 		today.set(MILLISECOND, 0);


### PR DESCRIPTION
Because in regions where it works with 24h, using `cal.set(Calendar.HOUR, 0)` can happen to set as 12AM instead of 12PM.

Like this:
```
I/System.out﹕ Tue Aug 25 12:00:00 BRT 2015
```

The correct would be:
```
I/System.out﹕ Tue Aug 25 00:00:00 BRT 2015
```