### PR TITLE
Adding @FieldsEqual validation annotation 

### DIFF
--- a/library/src/main/java/eu/inmite/android/lib/validations/form/FieldAdapterFactory.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/FieldAdapterFactory.java
@@ -26,6 +26,7 @@ import eu.inmite.android.lib.validations.form.iface.IFieldAdapter;
 public class FieldAdapterFactory {
 
 	private static JoinedAdapter sJoinedAdapter;
+	private static FieldEqualsAdapter sFieldsEqualsAdapter;
 	private static TextViewAdapter sTextViewAdapter;
 	private static SpinnerAdapter sSpinnerViewAdapter;
 	private static CompoundAdapter sCompoundViewAdapter;
@@ -52,10 +53,10 @@ public class FieldAdapterFactory {
 			}
 			adapter = sJoinedAdapter;
 		} else if (annotation != null && FieldsEqual.class.equals(annotation.annotationType())) {
-			if (sJoinedAdapter == null) {
-				sJoinedAdapter = new FieldEqualsAdapter();
+			if (sFieldsEqualsAdapter == null) {
+				sFieldsEqualsAdapter = new FieldEqualsAdapter();
 			}
-			adapter = sJoinedAdapter;
+			adapter = sFieldsEqualsAdapter;
 		} else if (sExternalAdapters != null && sExternalAdapters.containsKey(view.getClass())) {
 			adapter = sExternalAdapters.get(view.getClass());
         } else if (view instanceof CompoundButton) {
@@ -86,5 +87,6 @@ public class FieldAdapterFactory {
 		sJoinedAdapter = null;
 		sTextViewAdapter = null;
 		sSpinnerViewAdapter = null;
+		sFieldsEqualsAdapter = null;
 	}
 }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/FieldAdapterFactory.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/FieldAdapterFactory.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import eu.inmite.android.lib.validations.form.adapters.CompoundAdapter;
+import eu.inmite.android.lib.validations.form.adapters.FieldEqualsAdapter;
 import eu.inmite.android.lib.validations.form.adapters.JoinedAdapter;
 import eu.inmite.android.lib.validations.form.adapters.SpinnerAdapter;
 import eu.inmite.android.lib.validations.form.adapters.TextViewAdapter;
@@ -45,9 +46,14 @@ public class FieldAdapterFactory {
 
 	public static IFieldAdapter<? extends View,?> getAdapterForField(View view, Annotation annotation) {
 		final IFieldAdapter<? extends View,?> adapter;
-		if (annotation != null && Joined.class.equals(annotation.annotationType()) || annotation != null && FieldsEqual.class.equals(annotation.annotationType())) {
+		if (annotation != null && Joined.class.equals(annotation.annotationType())) {
 			if (sJoinedAdapter == null) {
 				sJoinedAdapter = new JoinedAdapter();
+			}
+			adapter = sJoinedAdapter;
+		} else if (annotation != null && FieldsEqual.class.equals(annotation.annotationType())) {
+			if (sJoinedAdapter == null) {
+				sJoinedAdapter = new FieldEqualsAdapter();
 			}
 			adapter = sJoinedAdapter;
 		} else if (sExternalAdapters != null && sExternalAdapters.containsKey(view.getClass())) {

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/FieldAdapterFactory.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/FieldAdapterFactory.java
@@ -13,6 +13,7 @@ import eu.inmite.android.lib.validations.form.adapters.CompoundAdapter;
 import eu.inmite.android.lib.validations.form.adapters.JoinedAdapter;
 import eu.inmite.android.lib.validations.form.adapters.SpinnerAdapter;
 import eu.inmite.android.lib.validations.form.adapters.TextViewAdapter;
+import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
 import eu.inmite.android.lib.validations.form.annotations.Joined;
 import eu.inmite.android.lib.validations.form.iface.IFieldAdapter;
 
@@ -44,7 +45,7 @@ public class FieldAdapterFactory {
 
 	public static IFieldAdapter<? extends View,?> getAdapterForField(View view, Annotation annotation) {
 		final IFieldAdapter<? extends View,?> adapter;
-		if (annotation != null && Joined.class.equals(annotation.annotationType())) {
+		if (annotation != null && Joined.class.equals(annotation.annotationType()) || annotation != null && FieldsEqual.class.equals(annotation.annotationType())) {
 			if (sJoinedAdapter == null) {
 				sJoinedAdapter = new JoinedAdapter();
 			}

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
@@ -3,8 +3,6 @@ package eu.inmite.android.lib.validations.form.adapters;
 import android.view.View;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
 
@@ -19,9 +17,10 @@ public class FieldEqualsAdapter extends JoinedAdapter {
         int[] viewIds = ((FieldsEqual) annotation).fields();
         View[] views = findViewsInView(viewIds, sourceView);
 
-        ArrayList<View> viewSet = new ArrayList<>(Arrays.asList(views));
-        viewSet.add(sourceView);
+        View[] outSet = new View[views.length + 1];
+        outSet[0] = sourceView;
+        System.arraycopy(views, 0, outSet, 1, views.length);
 
-        return viewSet.toArray(new View[viewSet.size()]);
+        return outSet;
     }
 }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
@@ -1,0 +1,21 @@
+package eu.inmite.android.lib.validations.form.adapters;
+
+import android.view.View;
+
+import java.lang.annotation.Annotation;
+
+import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
+
+/**
+ *
+ */
+public class FieldEqualsAdapter extends JoinedAdapter {
+
+    @Override
+    protected View[] getRelevantViewSet(Annotation annotation, View view) {
+        int[] viewIds = ((FieldsEqual) annotation).fields();
+        View[] views = findViewsInView(viewIds, view);
+
+        return views;
+    }
+}

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
@@ -3,11 +3,14 @@ package eu.inmite.android.lib.validations.form.adapters;
 import android.view.View;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
 
 /**
- *
+ * Adapter to provide views for the fields equal annotation. Ensures that source view gets passed along
+ * with other views specified in the annotation.
  */
 public class FieldEqualsAdapter extends JoinedAdapter {
 
@@ -16,9 +19,9 @@ public class FieldEqualsAdapter extends JoinedAdapter {
         int[] viewIds = ((FieldsEqual) annotation).fields();
         View[] views = findViewsInView(viewIds, sourceView);
 
-        View[] newViewSet = new View[views.length + 1];
-        newViewSet[newViewSet.length - 1] = sourceView;
+        ArrayList<View> viewSet = new ArrayList<>(Arrays.asList(views));
+        viewSet.add(sourceView);
 
-        return newViewSet;
+        return viewSet.toArray(new View[viewSet.size()]);
     }
 }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/FieldEqualsAdapter.java
@@ -12,10 +12,13 @@ import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
 public class FieldEqualsAdapter extends JoinedAdapter {
 
     @Override
-    protected View[] getRelevantViewSet(Annotation annotation, View view) {
+    protected View[] getRelevantViewSet(Annotation annotation, View sourceView) {
         int[] viewIds = ((FieldsEqual) annotation).fields();
-        View[] views = findViewsInView(viewIds, view);
+        View[] views = findViewsInView(viewIds, sourceView);
 
-        return views;
+        View[] newViewSet = new View[views.length + 1];
+        newViewSet[newViewSet.length - 1] = sourceView;
+
+        return newViewSet;
     }
 }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/JoinedAdapter.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/JoinedAdapter.java
@@ -5,7 +5,6 @@ import android.view.View;
 import java.lang.annotation.Annotation;
 
 import eu.inmite.android.lib.validations.form.FieldAdapterFactory;
-import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
 import eu.inmite.android.lib.validations.form.annotations.Joined;
 import eu.inmite.android.lib.validations.form.iface.IFieldAdapter;
 
@@ -17,14 +16,7 @@ public class JoinedAdapter implements IFieldAdapter<View, String[]> {
 
 	@Override
 	public String[] getFieldValue(Annotation annotation, View fieldView) {
-		int[] viewIds = new int[0];
-		if (annotation instanceof Joined) {
-			viewIds = ((Joined) annotation).value();
-		} else if (annotation instanceof FieldsEqual) {
-			viewIds = ((FieldsEqual) annotation).fields();
-		}
-
-		final View[] views = findViewsInView(viewIds, fieldView);
+		final View[] views = getRelevantViewSet(annotation, fieldView);
 
 		final String[] fieldValues = new String[views.length];
 		for (int i = 0; i < views.length; i++) {
@@ -34,7 +26,12 @@ public class JoinedAdapter implements IFieldAdapter<View, String[]> {
 		return fieldValues;
 	}
 
-	private String valueFromView(View view) {
+	protected View[] getRelevantViewSet(Annotation annotation, View view) {
+		int[] viewIds = ((Joined) annotation).value();
+		return findViewsInView(viewIds, view);
+	}
+
+	protected String valueFromView(View view) {
 		IFieldAdapter adapter = FieldAdapterFactory.getAdapterForField(view, null);
 		if (adapter != null) {
 			return String.valueOf(adapter.getFieldValue(null, view));
@@ -42,7 +39,7 @@ public class JoinedAdapter implements IFieldAdapter<View, String[]> {
 		return null;
 	}
 
-	private static View[] findViewsInView(int[] viewIds, View target) {
+	protected static View[] findViewsInView(int[] viewIds, View target) {
 		final View container = target.getRootView();
 		final View[] views = new View[viewIds.length];
 		for (int i = 0; i < viewIds.length; i++) {

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/JoinedAdapter.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/adapters/JoinedAdapter.java
@@ -5,6 +5,7 @@ import android.view.View;
 import java.lang.annotation.Annotation;
 
 import eu.inmite.android.lib.validations.form.FieldAdapterFactory;
+import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
 import eu.inmite.android.lib.validations.form.annotations.Joined;
 import eu.inmite.android.lib.validations.form.iface.IFieldAdapter;
 
@@ -16,7 +17,13 @@ public class JoinedAdapter implements IFieldAdapter<View, String[]> {
 
 	@Override
 	public String[] getFieldValue(Annotation annotation, View fieldView) {
-		final int[] viewIds = ((Joined) annotation).value();
+		int[] viewIds = new int[0];
+		if (annotation instanceof Joined) {
+			viewIds = ((Joined) annotation).value();
+		} else if (annotation instanceof FieldsEqual) {
+			viewIds = ((FieldsEqual) annotation).fields();
+		}
+
 		final View[] views = findViewsInView(viewIds, fieldView);
 
 		final String[] fieldValues = new String[views.length];

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/FieldsEqual.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/FieldsEqual.java
@@ -1,0 +1,22 @@
+package eu.inmite.android.lib.validations.form.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validate that 2 or more field values are all equal to each other
+ * @author Andrew Watson
+ */
+@Target(value= ElementType.FIELD)
+@Retention(value= RetentionPolicy.RUNTIME)
+public @interface FieldsEqual {
+
+    /**
+     * Ids of all views that will need to be equal to pass validation.
+     */
+    int[] value();
+    int messageId() default 0;
+    int order() default 1000;
+}

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/FieldsEqual.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/annotations/FieldsEqual.java
@@ -16,7 +16,7 @@ public @interface FieldsEqual {
     /**
      * Ids of all views that will need to be equal to pass validation.
      */
-    int[] value();
+    int[] fields();
     int messageId() default 0;
     int order() default 1000;
 }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
@@ -1,0 +1,26 @@
+package eu.inmite.android.lib.validations.form.validators;
+
+import android.util.Log;
+
+import java.lang.annotation.Annotation;
+
+import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
+import eu.inmite.android.lib.validations.form.annotations.ValidatorFor;
+
+/**
+ * @author Andrew Watson
+ */
+@ValidatorFor(FieldsEqual.class)
+public class EqualsValidator extends BaseValidator<String[]> {
+
+    @Override
+    public boolean validate(Annotation annotation, String[] fieldValues) {
+        if (fieldValues == null || fieldValues.length < 2) {
+            return false;
+        }
+
+        Log.v("Andrew", "You got here");
+
+        return false;
+    }
+}

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
@@ -17,6 +17,8 @@ public class EqualsValidator extends BaseValidator<String[]> {
             return false;
         }
 
+
+
         return false;
     }
 }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
@@ -1,7 +1,5 @@
 package eu.inmite.android.lib.validations.form.validators;
 
-import android.util.Log;
-
 import java.lang.annotation.Annotation;
 
 import eu.inmite.android.lib.validations.form.annotations.FieldsEqual;
@@ -18,8 +16,6 @@ public class EqualsValidator extends BaseValidator<String[]> {
         if (fieldValues == null || fieldValues.length < 2) {
             return false;
         }
-
-        Log.v("Andrew", "You got here");
 
         return false;
     }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/validators/EqualsValidator.java
@@ -17,8 +17,10 @@ public class EqualsValidator extends BaseValidator<String[]> {
             return false;
         }
 
+        for (String field : fieldValues) {
+            if (!field.equals(fieldValues[0])) { return false; }
+        }
 
-
-        return false;
+        return true;
     }
 }

--- a/library/src/main/java/eu/inmite/android/lib/validations/form/validators/ValidatorFactory.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/validators/ValidatorFactory.java
@@ -36,7 +36,8 @@ public class ValidatorFactory {
 				WeekendDateValidator.class,
 				FutureDateValidator.class,
 				RegExpValidator.class,
-                CheckedValidator.class);
+                CheckedValidator.class,
+				EqualsValidator.class);
 	}
 
 	public static void registerValidatorClasses(Class<? extends IValidator<?>>... classes) {


### PR DESCRIPTION
I thought this annotation would be useful for forms where one or more fields need to be equal (i.e. password/confirm password).

There is a "fields" property on the annotation where you provide an array of the other field ids that must be equal to the annotated field for validation to pass.

Let me know if you want unit tests included before accepting the PR.