### PR TITLE
Change Calendar.HOUR to Calendar.HOUR_OF_DAY

### DIFF
--- a/library/src/main/java/eu/inmite/android/lib/validations/form/validators/FutureDateValidator.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/validators/FutureDateValidator.java
@@ -43,7 +43,7 @@ public class FutureDateValidator extends BaseDateValidator {
 	@Override
 	protected boolean validateDate(final Calendar cal, final Annotation annotation) {
 		final Calendar today = Calendar.getInstance();
-		today.set(HOUR, 0);
+		today.set(HOUR_OF_DAY, 0);
 		today.set(MINUTE, 0);
 		today.set(SECOND, 0);
 		today.set(MILLISECOND, 0);


### PR DESCRIPTION
Because in regions where it works with 24h, using `cal.set(Calendar.HOUR, 0)` can happen to set as 12AM instead of 12PM.

Like this:
```
I/System.out﹕ Tue Aug 25 12:00:00 BRT 2015
```

The correct would be:
```
I/System.out﹕ Tue Aug 25 00:00:00 BRT 2015
```