### PR TITLE
Strange behavior of validateSingleView(...)

### DIFF
--- a/library/src/main/java/eu/inmite/android/lib/validations/form/FormValidator.java
+++ b/library/src/main/java/eu/inmite/android/lib/validations/form/FormValidator.java
@@ -286,7 +286,7 @@ public class FormValidator {
 	            callback.validationComplete(false, Collections.singletonList(validationFail), Collections.<View>emptyList());
             } else if (callback != null) {
                 final List<ValidationFail> noFailedValidations = Collections.emptyList();
-                overallResult = validate(formContainer.getContext(), target, null);
+                //overallResult = validate(formContainer.getContext(), target, null);
                 callback.validationComplete(overallResult, noFailedValidations, Collections.singletonList(targetView));
             }
         }


### PR DESCRIPTION
When a single view validation has succeeded, I don't want to have an all target (which can be potentially an activity or a fragment) validation that makes no sense if I had chosen to validate only a single view in the target.